### PR TITLE
unloading assetbundles

### DIFF
--- a/Assets/Scripts/LoadModels.cs
+++ b/Assets/Scripts/LoadModels.cs
@@ -69,6 +69,7 @@ public class LoadModels : MonoBehaviour
             LoadingCanvas.SetActive(false);
             MainCanvas.SetActive(true);
             Debug.Log("Success!!!");
+            assetBundle.Unload(false);
         }
         else
         {


### PR DESCRIPTION
I guess unloading bundles is always good practice cause
1. if u go back and again jump back to AR scene then it will throw error that can't load the model cause it's already present 2.as we r storing gameobject of this assetbundle in other scripts variable so it will not affect either way.